### PR TITLE
fixed remote method arguments | changed mongo connection | changed to English error messages

### DIFF
--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -912,7 +912,8 @@ GridFSService.prototype.upload.http = {
 GridFSService.prototype.download.shared = true;
 GridFSService.prototype.download.accepts = [
   { arg: 'fileId', type: 'string', description: 'File id' },
-  { arg: 'res', type: 'object', 'http': { source: 'res' } }
+  { arg: 'res', type: 'object', 'http': { source: 'res' } },
+  { arg: 'req', type: 'object', 'http': { source: 'req' } }
 ];
 GridFSService.prototype.download.http = {
   verb: 'get',

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -502,7 +502,7 @@ GridFSService.prototype.uploadWithMetadata = function (containerName, metadata, 
  * Download middleware for the HTTP request.
  */
 
-GridFSService.prototype.download = function (fileId, res, cb) {
+GridFSService.prototype.download = function (fileId, res, req, cb) {
   var self = this;
 
   var collection = this.db.collection('fs.files');
@@ -520,14 +520,39 @@ GridFSService.prototype.download = function (fileId, res, cb) {
     }
 
     var gridfs = new GridFS(self.db, mongodb);
-    var stream = gridfs.createReadStream({
-      _id: file._id
-    });
 
-    // set headers
     res.set('Content-Type', file.metadata.mimetype);
-    res.set('Content-Length', file.length);
+    res.set('Content-Transfer-Encoding','binary');
     res.set('Content-Disposition', `attachment;filename=${file.filename}`);
+
+    if (!!req.headers['range']){
+      rangeStart = parseInt(req.headers['range'].split('=')[1].split('-')[0]);
+      rangeEnd = parseInt(req.headers['range'].split('=')[1].split('-')[1]);
+    }
+
+    if (!req.headers['range'] || isNaN(rangeEnd)){
+      var stream = gridfs.createReadStream({
+        _id: file._id,
+      });
+      res.set('Content-Length', file.length);
+
+      res.status(200);
+
+    }else{
+
+      var stream = gridfs.createReadStream({
+        _id: file._id,
+        range: {
+          startPos: rangeStart,
+          endPos: rangeEnd,
+        }
+      });
+      res.set('Accept-Ranges', 'bytes');
+      res.set('Content-Length', rangeEnd + 1 - rangeStart);
+      res.set('Content-Range', `bytes ${rangeStart}-${rangeEnd}/${file.length}`);
+
+      res.status(206);
+    }
 
     return stream.pipe(res);
   });

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -6,6 +6,8 @@ const ZipStream = require('zip-stream');
 const mongodb = require('mongodb');
 const MongoClient = mongodb.MongoClient;
 
+var sharp = require('sharp');
+
 module.exports = GridFSService;
 
 function GridFSService(options) {
@@ -111,7 +113,7 @@ GridFSService.prototype.connect = function (cb) {
 
     var lbOptions = Object.keys(self.options);
     var validOptions = {};
-    lbOptions.forEach(function(option) {
+    lbOptions.forEach(function (option) {
       if (validOptionNames.indexOf(option) > -1) {
         validOptions[option] = self.options[option];
       }
@@ -430,6 +432,23 @@ GridFSService.prototype.upload = function (containerName, req, cb) {
     });
 
     stream.on('error', cb);
+
+    if (self.options.compressImages) {
+      const resize = sharp()
+        .rotate()
+        .resize(1500);
+
+      switch (mimetype) {
+        case 'image/jpg':
+        case 'image/jpeg':
+          file = file.pipe(resize.jpeg({ quality: 80 }));
+          break;
+        case 'image/png':
+        case 'image/gif':
+          file = file.pipe(resize.png({ compressionLevel: 8 }));
+          break;
+      }
+    }
 
     file.pipe(stream);
   });

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -40,7 +40,84 @@ GridFSService.prototype.connect = function (cb) {
 
     // connect
 
-    MongoClient.connect(url, self.options, (error, client) => {
+    // See https://github.com/mongodb/node-mongodb-native/blob/3.0.0/lib/mongo_client.js#L37
+    var validOptionNames = [
+      'poolSize',
+      'ssl',
+      'sslValidate',
+      'sslCA',
+      'sslCert',
+      'sslKey',
+      'sslPass',
+      'sslCRL',
+      'autoReconnect',
+      'noDelay',
+      'keepAlive',
+      'keepAliveInitialDelay',
+      'connectTimeoutMS',
+      'family',
+      'socketTimeoutMS',
+      'reconnectTries',
+      'reconnectInterval',
+      'ha',
+      'haInterval',
+      'replicaSet',
+      'secondaryAcceptableLatencyMS',
+      'acceptableLatencyMS',
+      'connectWithNoPrimary',
+      'authSource',
+      'w',
+      'wtimeout',
+      'j',
+      'forceServerObjectId',
+      'serializeFunctions',
+      'ignoreUndefined',
+      'raw',
+      'bufferMaxEntries',
+      'readPreference',
+      'pkFactory',
+      'promiseLibrary',
+      'readConcern',
+      'maxStalenessSeconds',
+      'loggerLevel',
+      'logger',
+      'promoteValues',
+      'promoteBuffers',
+      'promoteLongs',
+      'domainsEnabled',
+      'checkServerIdentity',
+      'validateOptions',
+      'appname',
+      'auth',
+      'user',
+      'password',
+      'authMechanism',
+      'compression',
+      'fsync',
+      'readPreferenceTags',
+      'numberOfRetries',
+      'auto_reconnect',
+      'minSize',
+      'useNewUrlParser',
+      // Ignored options
+      'native_parser',
+      // Legacy options
+      'server',
+      'replset',
+      'replSet',
+      'mongos',
+      'db',
+    ];
+
+    var lbOptions = Object.keys(self.options);
+    var validOptions = {};
+    lbOptions.forEach(function(option) {
+      if (validOptionNames.indexOf(option) > -1) {
+        validOptions[option] = self.options[option];
+      }
+    });
+
+    new MongoClient(url, validOptions).connect((error, client) => {
       if (!error) {
         self.db = client.db(self.options.database);
       }

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -668,7 +668,7 @@ GridFSService.prototype.deleteContainer.http = {
  */
 GridFSService.prototype.deleteContainer.shared = true;
 GridFSService.prototype.deleteContainer.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' }
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } }
 ];
 GridFSService.prototype.deleteContainer.returns = {};
 GridFSService.prototype.deleteContainer.http = {
@@ -681,7 +681,7 @@ GridFSService.prototype.deleteContainer.http = {
  */
 GridFSService.prototype.getFiles.shared = true;
 GridFSService.prototype.getFiles.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' }
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } }
 ];
 GridFSService.prototype.getFiles.returns = {
   type: 'array',
@@ -697,8 +697,8 @@ GridFSService.prototype.getFiles.http = {
  */
 GridFSService.prototype.getFile.shared = true;
 GridFSService.prototype.getFile.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' },
-  { arg: 'fileId', type: 'string', description: 'File id' }
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
+  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
 ];
 GridFSService.prototype.getFile.returns = {
   type: 'object',
@@ -714,8 +714,8 @@ GridFSService.prototype.getFile.http = {
  */
 GridFSService.prototype.getFileByName.shared = true;
 GridFSService.prototype.getFileByName.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' },
-  { arg: 'filename', type: 'string', description: 'File name' }
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
+  { arg: 'filename', type: 'string', description: 'File name', source: { source: 'path' } }
 ];
 GridFSService.prototype.getFileByName.returns = {
   type: 'object',
@@ -731,8 +731,8 @@ GridFSService.prototype.getFileByName.http = {
  */
 GridFSService.prototype.deleteFile.shared = true;
 GridFSService.prototype.deleteFile.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' },
-  { arg: 'fileId', type: 'string', description: 'File id' }
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
+  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
 ];
 GridFSService.prototype.deleteFile.returns = {};
 GridFSService.prototype.deleteFile.http = {
@@ -745,7 +745,7 @@ GridFSService.prototype.deleteFile.http = {
  */
 GridFSService.prototype.deleteFileByFileId.shared = true;
 GridFSService.prototype.deleteFileByFileId.accepts = [
-  { arg: 'fileId', type: 'string', description: 'File id' }
+  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
 ];
 GridFSService.prototype.deleteFileByFileId.returns = {};
 GridFSService.prototype.deleteFileByFileId.http = {
@@ -758,8 +758,8 @@ GridFSService.prototype.deleteFileByFileId.http = {
  */
 GridFSService.prototype.deleteFileByName.shared = true;
 GridFSService.prototype.deleteFileByName.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' },
-  { arg: 'filename', type: 'string', description: 'File name' }
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
+  { arg: 'filename', type: 'string', description: 'File name', source: { source: 'path' } }
 ];
 GridFSService.prototype.deleteFileByName.returns = {};
 GridFSService.prototype.deleteFileByName.http = {
@@ -772,7 +772,7 @@ GridFSService.prototype.deleteFileByName.http = {
  */
 GridFSService.prototype.upload.shared = true;
 GridFSService.prototype.upload.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' },
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
   { arg: 'req', type: 'object', http: { source: 'req' } }
 ];
 GridFSService.prototype.upload.returns = {
@@ -803,7 +803,7 @@ GridFSService.prototype.download.http = {
  */
 GridFSService.prototype.downloadContainer.shared = true;
 GridFSService.prototype.downloadContainer.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name' },
+  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
   { arg: 'req', type: 'object', 'http': { source: 'req' } },
   { arg: 'res', type: 'object', 'http': { source: 'res' } }
 ];
@@ -843,7 +843,7 @@ GridFSService.prototype.downloadInline.http = {
  */
 GridFSService.prototype.getStreamFileId.shared = true;
 GridFSService.prototype.getStreamFileId.accepts = [
-  { arg: 'fileId', type: 'string', description: 'File id' }
+  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
 ];
 GridFSService.prototype.getStreamFileId.http = {
   verb: 'get',

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -525,12 +525,12 @@ GridFSService.prototype.download = function (fileId, res, req, cb) {
     res.set('Content-Transfer-Encoding','binary');
     res.set('Content-Disposition', `attachment;filename=${file.filename}`);
 
-    if (!!req.headers['range']){
+    if (!!req.headers && !!req.headers['range']){
       rangeStart = parseInt(req.headers['range'].split('=')[1].split('-')[0]);
       rangeEnd = parseInt(req.headers['range'].split('=')[1].split('-')[1]);
     }
 
-    if (!req.headers['range'] || isNaN(rangeEnd)){
+    if (!req.headers || !req.headers['range'] || isNaN(rangeEnd)){
       var stream = gridfs.createReadStream({
         _id: file._id,
       });

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -294,7 +294,7 @@ GridFSService.prototype.getFile = function (containerName, fileId, cb) {
     'metadata.container': containerName
   }).limit(1).next(function (error, file) {
     if (!file) {
-      error = new Error('Fichero no encontrado.');
+      error = new Error('Not found.');
       error.status = 404;
     }
     return cb(error, file || {});
@@ -312,7 +312,7 @@ GridFSService.prototype.getFileByName = function (containerName, filename, cb) {
     'metadata.container': containerName
   }).limit(1).next(function (error, file) {
     if (!file) {
-      error = new Error('Fichero no encontrado');
+      error = new Error('Not found');
       error.status = 404;
     }
     return cb(error, file || {});
@@ -492,7 +492,7 @@ GridFSService.prototype.download = function (fileId, res, cb) {
     '_id': new mongodb.ObjectID(fileId)
   }).limit(1).next(function (error, file) {
     if (!file) {
-      error = new Error('Fichero no encontrado.');
+      error = new Error('Not found.');
       error.status = 404;
     }
 
@@ -622,7 +622,7 @@ GridFSService.prototype.downloadInline = function (fileId, res, cb) {
     '_id': new mongodb.ObjectID(fileId)
   }).limit(1).next(function (error, file) {
     if (!file) {
-      error = new Error('Fichero no encontrado.');
+      error = new Error('Not found.');
       error.status = 404;
     }
 
@@ -657,7 +657,7 @@ GridFSService.prototype.getStreamFileId = function (fileId, cb) {
     '_id': new mongodb.ObjectID(fileId)
   }).limit(1).next(function (error, file) {
     if (!file) {
-      error = new Error('Fichero no encontrado.');
+      error = new Error('Not found.');
       error.status = 404;
     }
 

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -668,7 +668,7 @@ GridFSService.prototype.deleteContainer.http = {
  */
 GridFSService.prototype.deleteContainer.shared = true;
 GridFSService.prototype.deleteContainer.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } }
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } }
 ];
 GridFSService.prototype.deleteContainer.returns = {};
 GridFSService.prototype.deleteContainer.http = {
@@ -681,7 +681,7 @@ GridFSService.prototype.deleteContainer.http = {
  */
 GridFSService.prototype.getFiles.shared = true;
 GridFSService.prototype.getFiles.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } }
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } }
 ];
 GridFSService.prototype.getFiles.returns = {
   type: 'array',
@@ -697,8 +697,8 @@ GridFSService.prototype.getFiles.http = {
  */
 GridFSService.prototype.getFile.shared = true;
 GridFSService.prototype.getFile.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
-  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } },
+  { arg: 'fileId', type: 'string', description: 'File id', http: { source: 'path' } }
 ];
 GridFSService.prototype.getFile.returns = {
   type: 'object',
@@ -714,8 +714,8 @@ GridFSService.prototype.getFile.http = {
  */
 GridFSService.prototype.getFileByName.shared = true;
 GridFSService.prototype.getFileByName.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
-  { arg: 'filename', type: 'string', description: 'File name', source: { source: 'path' } }
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } },
+  { arg: 'filename', type: 'string', description: 'File name', http: { source: 'path' } }
 ];
 GridFSService.prototype.getFileByName.returns = {
   type: 'object',
@@ -731,8 +731,8 @@ GridFSService.prototype.getFileByName.http = {
  */
 GridFSService.prototype.deleteFile.shared = true;
 GridFSService.prototype.deleteFile.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
-  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } },
+  { arg: 'fileId', type: 'string', description: 'File id', http: { source: 'path' } }
 ];
 GridFSService.prototype.deleteFile.returns = {};
 GridFSService.prototype.deleteFile.http = {
@@ -745,7 +745,7 @@ GridFSService.prototype.deleteFile.http = {
  */
 GridFSService.prototype.deleteFileByFileId.shared = true;
 GridFSService.prototype.deleteFileByFileId.accepts = [
-  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
+  { arg: 'fileId', type: 'string', description: 'File id', http: { source: 'path' } }
 ];
 GridFSService.prototype.deleteFileByFileId.returns = {};
 GridFSService.prototype.deleteFileByFileId.http = {
@@ -758,8 +758,8 @@ GridFSService.prototype.deleteFileByFileId.http = {
  */
 GridFSService.prototype.deleteFileByName.shared = true;
 GridFSService.prototype.deleteFileByName.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
-  { arg: 'filename', type: 'string', description: 'File name', source: { source: 'path' } }
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } },
+  { arg: 'filename', type: 'string', description: 'File name', http: { source: 'path' } }
 ];
 GridFSService.prototype.deleteFileByName.returns = {};
 GridFSService.prototype.deleteFileByName.http = {
@@ -772,7 +772,7 @@ GridFSService.prototype.deleteFileByName.http = {
  */
 GridFSService.prototype.upload.shared = true;
 GridFSService.prototype.upload.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } },
   { arg: 'req', type: 'object', http: { source: 'req' } }
 ];
 GridFSService.prototype.upload.returns = {
@@ -803,7 +803,7 @@ GridFSService.prototype.download.http = {
  */
 GridFSService.prototype.downloadContainer.shared = true;
 GridFSService.prototype.downloadContainer.accepts = [
-  { arg: 'containerName', type: 'string', description: 'Container name', source: { source: 'path' } },
+  { arg: 'containerName', type: 'string', description: 'Container name', http: { source: 'path' } },
   { arg: 'req', type: 'object', 'http': { source: 'req' } },
   { arg: 'res', type: 'object', 'http': { source: 'res' } }
 ];
@@ -843,7 +843,7 @@ GridFSService.prototype.downloadInline.http = {
  */
 GridFSService.prototype.getStreamFileId.shared = true;
 GridFSService.prototype.getStreamFileId.accepts = [
-  { arg: 'fileId', type: 'string', description: 'File id', source: { source: 'path' } }
+  { arg: 'fileId', type: 'string', description: 'File id', http: { source: 'path' } }
 ];
 GridFSService.prototype.getStreamFileId.http = {
   verb: 'get',

--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -830,7 +830,7 @@ GridFSService.prototype.downloadZipFiles.http = {
  */
 GridFSService.prototype.downloadInline.shared = true;
 GridFSService.prototype.downloadInline.accepts = [
-  { arg: 'fileId', type: 'string', description: 'File id' },
+  { arg: 'fileId', type: 'string', description: 'File id', http: { source: 'path' } },
   { arg: 'res', type: 'object', 'http': { source: 'res' } }
 ];
 GridFSService.prototype.downloadInline.http = {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gridfs-stream": "^1.1.1",
     "lodash": "^4.17.10",
     "mongodb": "^3.1.1",
+    "sharp": "^0.18.4",
     "zip-stream": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-component-storage-mongo-gridfs",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "loopback storage mongo gridfs component",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-component-storage-mongo-gridfs",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "loopback storage mongo gridfs component",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
- Made this small change so the "LoopBack Angular SDK" picks up the right param settings for the `:fileId` and `:filename`. The LoopBack SDK automatically picks up the first path argument correctly (:containerName) but then expects all the other params to be parsed in the "body" unless specifically told otherwise.. So then it will send a request as follows "host.example/Container/testContainer/files/:fileId?fileId=x".
- Changed the mongo connection as we required `replicaSet` support. Copied it from the LB's mongo connector.
- Finally translated the error messages to English :-) 